### PR TITLE
adding RedHat and OracleLinux matcher

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,7 +107,7 @@ class vsftpd::params {
   }
   $xferlog_file            = $::operatingsystem ? {
     /(?i:CentOS|Linux|RedHat)/ => '/var/log/xferlog',
-    default       => '/var/log/vsftpd/vsftpd.log',
+    default                    => '/var/log/vsftpd/vsftpd.log',
   }
 
   $port = '21'


### PR DESCRIPTION
Dropping in OS matcher for RedHat and OracleLinux similar to ones found in your other modules.  Have tested on OracleLinux.
