### PR TITLE
params.pp: use osfamily instead of operatingsystem to match more distributions.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -36,18 +36,18 @@ class vsftpd::params {
     default => '',
   }
 
-  $process_user = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => 'root',
-    default                   => 'vsftpd',
+  $process_user = $::osfamily ? {
+    /Debian/ => 'root',
+    default  => 'vsftpd',
   }
 
   $config_dir = $::operatingsystem ? {
     default => '/etc/vsftpd',
   }
 
-  $config_file = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/etc/vsftpd.conf',
-    default                   => '/etc/vsftpd/vsftpd.conf',
+  $config_file = $::osfamily ? {
+    /Debian/ => '/etc/vsftpd.conf',
+    default  => '/etc/vsftpd/vsftpd.conf',
   }
 
   $config_file_mode = $::operatingsystem ? {
@@ -62,19 +62,19 @@ class vsftpd::params {
     default => 'root',
   }
 
-  $config_file_init = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/etc/default/vsftpd',
-    default                   => '/etc/sysconfig/vsftpd',
+  $config_file_init = $::osfamily ? {
+    /Debian/ => '/etc/default/vsftpd',
+    default  => '/etc/sysconfig/vsftpd',
   }
 
-  $pid_file = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/var/run/vsftpd/vsftpd.pid',
-    default                   => '/var/run/vsftpd.pid',
+  $pid_file = $::osfamily ? {
+    /Debian/ => '/var/run/vsftpd/vsftpd.pid',
+    default  => '/var/run/vsftpd.pid',
   }
 
-  $data_dir = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/srv/ftp',
-    default                   => '/var/ftp/pub',
+  $data_dir = $::osfamily ? {
+    /Debian/ => '/srv/ftp',
+    default  => '/var/ftp/pub',
   }
 
   $log_dir = $::operatingsystem ? {
@@ -85,18 +85,18 @@ class vsftpd::params {
   $anon_mkdir_write_enable = true
   $anon_upload_enable      = false
   $chroot_list_enable      = true
-  $chroot_list_file        = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/etc/vsftpd.chroot_list',
-    default                   => '/etc/vsftpd/chroot_list',
+  $chroot_list_file        = $::osfamily ? {
+    /Debian/ => '/etc/vsftpd.chroot_list',
+    default  => '/etc/vsftpd/chroot_list',
   }
   $chroot_list_file_source = 'puppet:///modules/vsftpd/chroot_list'
   $chroot_local_user       = false
   $connect_from_port_20    = true
   $data_connection_timeout = '120'
   $deny_email_enable       = false
-  $banned_email_file       = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/etc/vsftpd.banned_emails',
-    default                   => '/etc/vsftpd/banned_emails',
+  $banned_email_file       = $::osfamily ? {
+    /Debian/ => '/etc/vsftpd.banned_emails',
+    default  => '/etc/vsftpd/banned_emails',
   }
   $dirmessage_enable       = true
   $ftpd_banner             = "Welcome to ${::fqdn} FTP service."
@@ -114,31 +114,31 @@ class vsftpd::params {
   $pam_service_name        = 'vsftpd'
   $pasv_max_port           = 0
   $pasv_min_port           = 0
-  $secure_chroot_dir       = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/var/run/vsftpd/empty',
-    default                   => '/usr/share/empty',
+  $secure_chroot_dir       = $::osfamily ? {
+    /Debian/ => '/var/run/vsftpd/empty',
+    default  => '/usr/share/empty',
   }
   $tcp_wrappers            = false
   $use_localtime           = false
   $user_config_dir         = ''
   $userlist_enable         = true
-  $userlist_file           = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => '/etc/vsftpd.user_list',
-    default                   => '/etc/vsftpd/user_list',
+  $userlist_file           = $::osfamily ? {
+    /Debian/ => '/etc/vsftpd.user_list',
+    default  => '/etc/vsftpd/user_list',
   }
   $userlist_file_source    = 'puppet:///modules/vsftpd/user_list'
   $user_sub_token          = ''
   $virtual_use_local_privs = false
   $write_enable            = true
   $xferlog_enable          = true
-  $xferlog_std_format      = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/ => false,
-    default                   => true,
+  $xferlog_std_format      = $::osfamily ? {
+    /Debian/ => false,
+    default  => true,
   }
-  $xferlog_file            = $::operatingsystem ? {
-    /(?i:Debian|Ubuntu|Mint)/  => '/var/log/vsftpd.log',
-    /(?i:CentOS|Linux|RedHat)/ => '/var/log/xferlog',
-    default                    => '/var/log/vsftpd/vsftpd.log',
+  $xferlog_file            = $::osfamily ? {
+    /Debian/      => '/var/log/vsftpd.log',
+    /(?i:RedHat)/ => '/var/log/xferlog',
+    default       => '/var/log/vsftpd/vsftpd.log',
   }
   $dual_log_enable         = false
   $allow_writeable_chroot  = false


### PR DESCRIPTION
Usage of osfamily instead of operatingsystem in selectors allows to use module on RHEL-like system such as Scientific Linux.
It should be backward compatible.
