### PR TITLE
Additional options, adjusted variable evaluation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -496,6 +496,11 @@
 # FTP clients, so you may want to disable it.
 # Default: YES
 #
+# [*seccomp_sandbox*]
+# If set to yes, process is run within a seccomp sandbox and hence is only allowed to make use of a limited set
+# of system calls, such as exit(), sigreturn(), read() and write() to opened file descriptors.
+# Default: YES
+#
 ###############################################################################################
 #
 # == Examples
@@ -612,6 +617,7 @@ class vsftpd (
   $cmds_allowed            = params_lookup( 'cmds_allowed' ),
   $setproctitle_enable     = params_lookup( 'setproctitle_enable' ),
   $pasv_promiscuous        = params_lookup( 'pasv_promiscuous' ),
+  $seccomp_sandbox         = params_lookup( 'seccomp_sandbox' ),
 
   ) inherits vsftpd::params {
 
@@ -665,6 +671,7 @@ class vsftpd (
   $bool_debug_ssl=any2bool($debug_ssl)
   $bool_setproctitle_enable=any2bool($setproctitle_enable)
   $bool_pasv_promiscuous=any2bool($pasv_promiscuous)
+  $bool_seccomp_sandbox=any2bool($seccomp_sandbox)
 
 
   # Template files variables
@@ -840,6 +847,11 @@ class vsftpd (
   }
 
   $real_pasv_promiscuous = $vsftpd::bool_pasv_promiscuous ? {
+    true  => 'YES',
+    false => 'NO',
+  }
+
+  $real_seccomp_sandbox = $vsftpd::bool_seccomp_sandbox ? {
     true  => 'YES',
     false => 'NO',
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -361,6 +361,19 @@
 # there is a mechanism for per-IP based configuration. If tcp_wrappers sets the
 # VSFTPD_LOAD_CONF environment variable, then the vsftpd session will try and
 # load the vsftpd configuration file specified in this variable.
+#
+# [*pasv_address*]
+# Use this option to override the IP address that vsftpd will advertise in response
+# to the PASV command. Provide a numeric IP address, unless pasv_addr_resolve is
+# enabled, in which case you can provide a hostname which will be DNS resolved
+# for you at startup.
+# Default: (none - the address is taken from the incoming connected socket)
+#
+# [*pasv_addr_resolve*]
+# Set to YES if you want to use a hostname (as opposed to IP address) in the
+# pasv_address option.
+# Default: NO
+#
 # [*pasv_max_port*]
 # The maximum port to allocate for PASV style data connections. Can be used to
 # specify a narrow port range to assist firewalling.
@@ -573,6 +586,8 @@ class vsftpd (
   $guest_username          = params_lookup( 'guest_username' ),
   $user_config_dir         = params_lookup( 'user_config_dir' ),
   $local_root              = params_lookup( 'local_root' ),
+  $pasv_address            = params_lookup( 'pasv_address' ),
+  $pasv_addr_resolve       = params_lookup( 'pasv_addr_resolve' ),
   $pasv_max_port           = params_lookup( 'pasv_max_port' ),
   $pasv_min_port           = params_lookup( 'pasv_min_port' ),
   $user_sub_token          = params_lookup( 'user_sub_token' ),
@@ -634,6 +649,7 @@ class vsftpd (
   $bool_xferlog_enable=any2bool($xferlog_enable)
   $bool_xferlog_std_format=any2bool($xferlog_std_format)
   $bool_guest_enable=any2bool($guest_enable)
+  $bool_pasv_addr_resolve=any2bool($pasv_addr_resolve)
   $bool_virtual_use_local_privs=any2bool($virtual_use_local_privs)
   $bool_hide_ids=any2bool($hide_ids)
   $bool_log_ftp_protocol=any2bool($log_ftp_protocol)
@@ -744,6 +760,11 @@ class vsftpd (
   }
 
   $real_guest_enable = $vsftpd::bool_guest_enable ? {
+    true  => 'YES',
+    false => 'NO',
+  }
+
+  $real_pasv_addr_resolve = $vsftpd::bool_pasv_addr_resolve ? {
     true  => 'YES',
     false => 'NO',
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -159,6 +159,7 @@ class vsftpd::params {
   $cmds_allowed            = ''
   $setproctitle_enable     = false
   $pasv_promiscuous        = false
+  $seccomp_sandbox         = true
 
   $port = '21'
   $protocol = 'tcp'

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -160,6 +160,26 @@ tcp_wrappers=<%= scope.lookupvar('vsftpd::real_tcp_wrappers') %>
 #tcp_wrappers=NO
 <% end-%>
 #
+# Use this option to override the IP address that vsftpd will advertise in response
+# to the PASV command. Provide a numeric IP address, unless pasv_addr_resolve is
+# enabled, in which case you can provide a hostname which will be DNS resolved
+# for you at startup.
+# Default: (none - the address is taken from the incoming connected socket)
+<% if scope.lookupvar('vsftpd::pasv_address') -%>
+pasv_address=<%= scope.lookupvar('vsftpd::pasv_address') %>
+<% else -%>
+#pasv_address=
+<% end-%>
+#
+# Set to YES if you want to use a hostname (as opposed to IP address) in the
+# pasv_address option.
+# Default: NO
+<% if scope.lookupvar('vsftpd::bool_pasv_addr_resolve') -%>
+pasv_addr_resolve=<%= scope.lookupvar('vsftpd::real_pasv_addr_resolve') %>
+<% else -%>
+#pasv_addr_resolve=NO
+<% end-%>
+#
 # The maximum port to allocate for PASV style data connections. Can be used
 # to specify a narrow port range to assist firewalling.
 # Default: 0 (use any port)

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -390,3 +390,12 @@ pasv_promiscuous=<%= scope.lookupvar('vsftpd::real_pasv_promiscuous') %>
 <% else -%>
 #pasv_promiscuous=NO
 <% end-%>
+
+# If set to yes, process is run within a seccomp sandbox and hence is only allowed to make use of a limited set
+# of system calls, such as exit(), sigreturn(), read() and write() to opened file descriptors.
+# Default: YES
+<% if defined?('vsftpd::bool_seccomp_syndbox') -%>
+seccomp_sandbox=<%= scope.lookupvar('vsftpd::real_seccomp_sandbox') %>
+<% else -%>
+#seccomp_sandbox=YES
+<% end-%>

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -300,7 +300,7 @@ rsa_private_key_file=<%= scope.lookupvar('vsftpd::rsa_private_key_file') %>
 # If activated, all non-anonymous logins are forced to use a secure SSL connection in order to 
 # send and receive data on data connections. 
 # Default: YES
-<% if scope.lookupvar('vsftpd::bool_force_local_data_ssl') -%>
+<% if defined?('vsftpd::bool_force_local_data_ssl') -%>
 force_local_data_ssl=<%= scope.lookupvar('vsftpd::real_force_local_data_ssl') %>
 <% else -%>
 #force_local_data_ssl=YES
@@ -309,7 +309,7 @@ force_local_data_ssl=<%= scope.lookupvar('vsftpd::real_force_local_data_ssl') %>
 # If activated, all non-anonymous logins are forced to use a secure SSL connection in order to 
 # send the password. 
 # Default: YES
-<% if scope.lookupvar('vsftpd::bool_force_local_logins_ssl') -%>
+<% if defined?('vsftpd::bool_force_local_logins_ssl') -%>
 force_local_logins_ssl=<%= scope.lookupvar('vsftpd::real_force_local_logins_ssl') %>
 <% else -%>
 #force_local_logins_ssl=YES
@@ -319,7 +319,7 @@ force_local_logins_ssl=<%= scope.lookupvar('vsftpd::real_force_local_logins_ssl'
 # know the same master secret as the control channel). Although this is a secure default, it may break many
 # FTP clients, so you may want to disable it.
 # Default: YES
-<% if ! scope.lookupvar('vsftpd::bool_require_ssl_reuse') -%>
+<% if defined?('vsftpd::bool_require_ssl_reuse') -%>
 require_ssl_reuse=<%= scope.lookupvar('vsftpd::real_require_ssl_reuse') %>
 <% else -%>
 #require_ssl_reuse=YES
@@ -337,7 +337,7 @@ ssl_ciphers=<%= scope.lookupvar('vsftpd::ssl_ciphers') %>
 
 # If true, OpenSSL connection diagnostics are dumped to the vsftpd log file.
 # Default: NO
-<% if scope.lookupvar('vsftpd::bool_debug_ssl') -%>
+<% if defined?('vsftpd::bool_debug_ssl') -%>
 debug_ssl=<%= scope.lookupvar('vsftpd::real_debug_ssl') %>
 <% else -%>
 #debug_ssl=NO


### PR DESCRIPTION
Hi,

please cross check these commits. We'd appreciate any comments or even integration into master ;)

1. variable evaluation:
Changed for specific parameters where the default would use 'YES' but 'NO' is required. Using scope.lookupvar('bool_*') evaluates to false, the parameter is not added and defaults apply - which is 'YES'. Using a defined?() instead allows us to have such parameters be defined with the required 'NO' value.

2. adding pasv_address and pasv_addr_resolve parameters

3. adding seccomp_sandbox parameter
Which seems to be required on some maschines. I.e. https://bugzilla.redhat.com/show_bug.cgi?id=845980

Thanks!
David, Jan, Mathias