### PR TITLE
only versions 3.+ support seccomp_sandbox

### DIFF
--- a/lib/facter/vsftpd_installed_version.rb
+++ b/lib/facter/vsftpd_installed_version.rb
@@ -1,0 +1,9 @@
+require 'facter/util/resolution'
+
+output = Facter::Util::Resolution.exec('vsftpd -v 0>&1') || 'vsftpd: version 0'
+
+Facter.add(:vsftpd_installed_version) do
+  setcode do
+    output.gsub(/^vsftpd: version ([\d\.]+)$/, '\1')
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -851,6 +851,12 @@ class vsftpd (
     false => 'NO',
   }
 
+  if versioncmp($::vsftpd_installed_version, '3.0') < 1 {
+    $supports_seccomp_sandbox = false
+  } else {
+    $supports_seccomp_sandbox = true
+  }
+
   $real_seccomp_sandbox = $vsftpd::bool_seccomp_sandbox ? {
     true  => 'YES',
     false => 'NO',

--- a/templates/vsftpd.conf.erb
+++ b/templates/vsftpd.conf.erb
@@ -391,6 +391,7 @@ pasv_promiscuous=<%= scope.lookupvar('vsftpd::real_pasv_promiscuous') %>
 #pasv_promiscuous=NO
 <% end-%>
 
+<% if scope.lookupvar('vsftpd::supports_seccomp_sandbox') -%>
 # If set to yes, process is run within a seccomp sandbox and hence is only allowed to make use of a limited set
 # of system calls, such as exit(), sigreturn(), read() and write() to opened file descriptors.
 # Default: YES
@@ -398,4 +399,5 @@ pasv_promiscuous=<%= scope.lookupvar('vsftpd::real_pasv_promiscuous') %>
 seccomp_sandbox=<%= scope.lookupvar('vsftpd::real_seccomp_sandbox') %>
 <% else -%>
 #seccomp_sandbox=YES
-<% end-%>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
Hope you don't mind using an extra fact to determine current vsftpd version. It seemed a bit cleaner to me compared to having a list of different OS and their individual versions.